### PR TITLE
Fix symlink path canonicalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "lsblk"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lsblk"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["madonuko <mado@fyralabs.com>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,14 @@ fn ls_symlinks(
         .filter(|f| f.metadata().is_ok_and(|f| f.is_symlink()))
         .map(|f| {
             let target = std::fs::read_link(f.path())?;
-            let target = target.strip_prefix("../../")?.to_string_lossy().to_string();
+            let target = f
+                .path()
+                .parent()
+                .unwrap()
+                .join(target)
+                .canonicalize()?
+                .to_string_lossy()
+                .to_string();
             let source = f.file_name().to_string_lossy().to_string();
             Ok((target, source))
         }))
@@ -123,5 +130,7 @@ impl BlockDevice {
 #[cfg(target_os = "linux")]
 #[test]
 fn test_lsblk_smoke() {
-    BlockDevice::list().expect("Valid lsblk");
+    let a = BlockDevice::list().expect("Valid lsblk");
+
+    println!("{:#?}", a);
 }


### PR DESCRIPTION
BREAKING CHANGE: `.name` now returns an absolute path instead of just the device name stripped